### PR TITLE
SW-1963 Reflect changes in grblHAL core module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(grbl INTERFACE)
 target_sources(grbl INTERFACE
  ${CMAKE_CURRENT_LIST_DIR}/grbllib.c
  ${CMAKE_CURRENT_LIST_DIR}/coolant_control.c
+ ${CMAKE_CURRENT_LIST_DIR}/corexy.c
  ${CMAKE_CURRENT_LIST_DIR}/nvs_buffer.c
  ${CMAKE_CURRENT_LIST_DIR}/gcode.c
  ${CMAKE_CURRENT_LIST_DIR}/machine_limits.c

--- a/config.h
+++ b/config.h
@@ -495,7 +495,7 @@ __NOTE:__ these definitions are only referenced in this file. Do __NOT__ change!
 //#define DEFAULT_NO_REPORT_WORK_COORD_OFFSET
 //#define DEFAULT_NO_REPORT_OVERRIDES
 //#define DEFAULT_REPORT_PARSER_STATE
-//#define DEFAULT_REPORT_ALARM_SUBSTATE
+#define DEFAULT_REPORT_ALARM_SUBSTATE
 
 // G92 offsets is by default stored to non-volatile storage (NVS) on changes and restored on startup
 // if COMPATIBILITY_LEVEL is <= 1. If COMPATIBILITY_LEVEL is <= 1 then setting $384 can be used to change this at run-time.
@@ -529,8 +529,8 @@ __NOTE:__ these definitions are only referenced in this file. Do __NOT__ change!
 //#define DEFAULT_X_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
 //#define DEFAULT_Y_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
 //#define DEFAULT_Z_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
-//#define DEFAULT_X_MAX_TRAVEL 200.0f // mm NOTE: Must be a positive value.
-//#define DEFAULT_Y_MAX_TRAVEL 200.0f // mm NOTE: Must be a positive value.
+#define DEFAULT_X_MAX_TRAVEL 507.0f // mm NOTE: Must be a positive value.
+#define DEFAULT_Y_MAX_TRAVEL 390.0f // mm NOTE: Must be a positive value.
 //#define DEFAULT_Z_MAX_TRAVEL 200.0f // mm NOTE: Must be a positive value.
 //#define DEFAULT_X_CURRENT 0.0 // amps
 //#define DEFAULT_Y_CURRENT 0.0 // amps

--- a/config.h
+++ b/config.h
@@ -494,7 +494,7 @@ __NOTE:__ these definitions are only referenced in this file. Do __NOT__ change!
 //#define DEFAULT_NO_REPORT_PIN_STATE
 //#define DEFAULT_NO_REPORT_WORK_COORD_OFFSET
 //#define DEFAULT_NO_REPORT_OVERRIDES
-//#define DEFAULT_REPORT_PARSER_STATE
+#define DEFAULT_REPORT_PARSER_STATE
 #define DEFAULT_REPORT_ALARM_SUBSTATE
 
 // G92 offsets is by default stored to non-volatile storage (NVS) on changes and restored on startup
@@ -529,8 +529,8 @@ __NOTE:__ these definitions are only referenced in this file. Do __NOT__ change!
 //#define DEFAULT_X_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
 //#define DEFAULT_Y_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
 //#define DEFAULT_Z_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
-#define DEFAULT_X_MAX_TRAVEL 507.0f // mm NOTE: Must be a positive value.
-#define DEFAULT_Y_MAX_TRAVEL 390.0f // mm NOTE: Must be a positive value.
+#define DEFAULT_X_MAX_TRAVEL 507.0f // mm NOTE: Must be a positive value. Arbitrary value that can be updated later by testing the Mr Beam device or setting during runtime.
+#define DEFAULT_Y_MAX_TRAVEL 390.0f // mm NOTE: Must be a positive value. Arbitrary value that can be updated later by testing the Mr Beam device or setting during runtime.
 //#define DEFAULT_Z_MAX_TRAVEL 200.0f // mm NOTE: Must be a positive value.
 //#define DEFAULT_X_CURRENT 0.0 // amps
 //#define DEFAULT_Y_CURRENT 0.0 // amps

--- a/config.h
+++ b/config.h
@@ -96,7 +96,7 @@ __NOTE:__ if switching to a level > 1 please reset non-volatile storage with \a 
 // defined at (http://corexy.com/theory.html). Motors are assumed to positioned and wired exactly as
 // described, if not, motions may move in strange directions. Grbl requires the CoreXY A and B motors
 // have the same steps per mm internally.
-//#define COREXY // Default disabled. Uncomment to enable.
+#define COREXY // Default disabled. Uncomment to enable.
 
 // Add a short delay for each block processed in Check Mode to
 // avoid overwhelming the sender with fast reply messages.

--- a/grbllib.c
+++ b/grbllib.c
@@ -267,7 +267,7 @@ int grbl_enter (void)
 
         // Print welcome message. Indicates an initialization has occurred at power-up or with a reset.
         report_init_message();
-        watchdog_update();
+        watchdog_update(); // Updates the watchdog that is set in the bootloader, ensures that the WD is not reset upon the intial boot sequence.
         if(state_get() == STATE_ESTOP)
             state_set(STATE_ALARM);
 

--- a/grbllib.c
+++ b/grbllib.c
@@ -35,6 +35,7 @@
 #include "state_machine.h"
 #include "nvs_buffer.h"
 #include "stream.h"
+#include "hardware/watchdog.h"
 #ifdef ENABLE_BACKLASH_COMPENSATION
 #include "motion_control.h"
 #endif
@@ -266,7 +267,7 @@ int grbl_enter (void)
 
         // Print welcome message. Indicates an initialization has occurred at power-up or with a reset.
         report_init_message();
-
+        watchdog_update();
         if(state_get() == STATE_ESTOP)
             state_set(STATE_ALARM);
 


### PR DESCRIPTION
* Include corexy.c in the cmakelists.
* Enable the define for corexy in config.h.